### PR TITLE
Enable building LEMON with C++20

### DIFF
--- a/lemon/random.h
+++ b/lemon/random.h
@@ -249,8 +249,8 @@ namespace lemon {
 
         current = state + length;
 
-        register Word *curr = state + length - 1;
-        register long num;
+        Word *curr = state + length - 1;
+        long num;
 
         num = length - shift;
         while (num--) {


### PR DESCRIPTION
This allows the project to be build with `CMAKE_CXX_STANDARD=20`.

It previously failed because it used the removed `register` keyword in `random.h`. As `register` was only a compiler hint, it does to change any program logic.

This paves the way to allow building LEMON in AliceVision as an embedded dependency with the general `CMAKE_CORE_BUILD_FLAGS`, which set `CMAKE_CXX_STANDARD=20` (see [here](https://github.com/alicevision/AliceVision/blob/fa2f0dad93192d2c3674b6eef47711522052d0a3/src/cmake/Dependencies.cmake#L100-L107)).