### PR TITLE
Dev/modernization cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,69 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Linker files
+*.ilk
+
+# Debugger Files
+*.pdb
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+*.so.*
+
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Build directories
+build/
+Build/
+build-*/
+
+# CMake generated files
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+Makefile
+install_manifest.txt 
+compile_commands.json
+
+# Temporary files
+*.tmp 
+*.log 
+*.bak 
+*.swp 
+
+# vcpkg
+vcpkg_installed/
+
+# debug information files
+*.dwo
+
+# test output & cache
+Testing/
+.cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,375 +1,394 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+cmake_minimum_required(VERSION 3.21)
 
-CMAKE_POLICY(SET CMP0048 OLD)
-
-SET(PROJECT_NAME "LEMON")
-PROJECT(${PROJECT_NAME})
-
-INCLUDE(FindPythonInterp)
-INCLUDE(FindWget)
-
-IF(EXISTS ${PROJECT_SOURCE_DIR}/cmake/version.cmake)
-  INCLUDE(${PROJECT_SOURCE_DIR}/cmake/version.cmake)
-ELSEIF(DEFINED ENV{LEMON_VERSION})
-  SET(LEMON_VERSION $ENV{LEMON_VERSION} CACHE STRING "LEMON version string.")
-ELSE()
-  EXECUTE_PROCESS(
-    COMMAND
-    hg log -r. --template "{latesttag}"
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-    OUTPUT_VARIABLE HG_REVISION_TAG
-    ERROR_QUIET
-    OUTPUT_STRIP_TRAILING_WHITESPACE
+# ---------------------------------------------------------------------------
+# Version
+# Priority: cmake/version.cmake > ENV{LEMON_VERSION} > FATAL_ERROR
+# ---------------------------------------------------------------------------
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.cmake")
+  include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.cmake")
+elseif(DEFINED ENV{LEMON_VERSION})
+  set(LEMON_VERSION "$ENV{LEMON_VERSION}" CACHE STRING "LEMON version string.")
+else()
+  message(FATAL_ERROR
+    "LEMON version could not be determined.\n"
+    "Please set the LEMON_VERSION environment variable before configuring.\n"
+    "Example: LEMON_VERSION=1.3.1 cmake ..."
   )
-  EXECUTE_PROCESS(
-    COMMAND
-    hg log -r. --template "{latesttagdistance}"
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-    OUTPUT_VARIABLE HG_REVISION_DIST
-    ERROR_QUIET
-    OUTPUT_STRIP_TRAILING_WHITESPACE
+endif()
+
+# ---------------------------------------------------------------------------
+# Project
+# ---------------------------------------------------------------------------
+project(LEMON
+  VERSION   "${LEMON_VERSION}"
+  LANGUAGES C CXX
+)
+
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+
+# ---------------------------------------------------------------------------
+# C++ standard
+# ---------------------------------------------------------------------------
+set(CMAKE_CXX_STANDARD          20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS        OFF)
+
+# ---------------------------------------------------------------------------
+# Optional dependencies (documentation)
+# ---------------------------------------------------------------------------
+find_package(Doxygen OPTIONAL_COMPONENTS dot)
+find_package(Ghostscript QUIET)
+
+# ---------------------------------------------------------------------------
+# Optional solver back-ends
+# ---------------------------------------------------------------------------
+option(LEMON_ENABLE_GLPK   "Enable GLPK solver backend."         ON)
+option(LEMON_ENABLE_ILOG   "Enable ILOG (CPLEX) solver backend." ON)
+option(LEMON_ENABLE_COIN   "Enable COIN solver backend."         ON)
+option(LEMON_ENABLE_SOPLEX "Enable SoPlex solver backend."       ON)
+
+if(LEMON_ENABLE_GLPK)
+  find_package(GLPK 4.33 QUIET)
+endif()
+if(LEMON_ENABLE_ILOG)
+  find_package(ILOG QUIET)
+endif()
+if(LEMON_ENABLE_COIN)
+  find_package(COIN QUIET)
+endif()
+if(LEMON_ENABLE_SOPLEX)
+  find_package(SOPLEX QUIET)
+endif()
+
+# Capability flags derived from found solvers
+if(GLPK_FOUND)
+  set(LEMON_HAVE_LP   TRUE)
+  set(LEMON_HAVE_MIP  TRUE)
+  set(LEMON_HAVE_GLPK TRUE)
+endif()
+if(ILOG_FOUND)
+  set(LEMON_HAVE_LP    TRUE)
+  set(LEMON_HAVE_MIP   TRUE)
+  set(LEMON_HAVE_CPLEX TRUE)
+endif()
+if(COIN_FOUND)
+  set(LEMON_HAVE_LP  TRUE)
+  set(LEMON_HAVE_MIP TRUE)
+  set(LEMON_HAVE_CLP TRUE)
+  set(LEMON_HAVE_CBC TRUE)
+endif()
+if(SOPLEX_FOUND)
+  set(LEMON_HAVE_LP     TRUE)
+  set(LEMON_HAVE_SOPLEX TRUE)
+endif()
+
+# Default LP / MIP solver selection (priority: CPLEX > CLP/CBC > GLPK > SOPLEX)
+if(ILOG_FOUND)
+  set(_default_lp  "CPLEX")
+  set(_default_mip "CPLEX")
+elseif(COIN_FOUND)
+  set(_default_lp  "CLP")
+  set(_default_mip "CBC")
+elseif(GLPK_FOUND)
+  set(_default_lp  "GLPK")
+  set(_default_mip "GLPK")
+elseif(SOPLEX_FOUND)
+  set(_default_lp  "SOPLEX")
+  set(_default_mip "")
+else()
+  set(_default_lp  "")
+  set(_default_mip "")
+endif()
+
+# Validate / reset cached LP choice if the corresponding library is not found
+set(_lp_needs_reset FALSE)
+if(NOT LEMON_DEFAULT_LP)
+  set(_lp_needs_reset TRUE)
+elseif((LEMON_DEFAULT_LP STREQUAL "CPLEX"  AND NOT ILOG_FOUND)   OR
+       (LEMON_DEFAULT_LP STREQUAL "CLP"    AND NOT COIN_FOUND)   OR
+       (LEMON_DEFAULT_LP STREQUAL "GLPK"   AND NOT GLPK_FOUND)   OR
+       (LEMON_DEFAULT_LP STREQUAL "SOPLEX" AND NOT SOPLEX_FOUND))
+  set(_lp_needs_reset TRUE)
+endif()
+set(LEMON_DEFAULT_LP "${_default_lp}" CACHE STRING
+  "Default LP solver backend (GLPK, CPLEX, CLP or SOPLEX)"
+  FORCE)
+
+set(_mip_needs_reset FALSE)
+if(NOT LEMON_DEFAULT_MIP)
+  set(_mip_needs_reset TRUE)
+elseif((LEMON_DEFAULT_MIP STREQUAL "CPLEX" AND NOT ILOG_FOUND) OR
+       (LEMON_DEFAULT_MIP STREQUAL "CBC"   AND NOT COIN_FOUND) OR
+       (LEMON_DEFAULT_MIP STREQUAL "GLPK"  AND NOT GLPK_FOUND))
+  set(_mip_needs_reset TRUE)
+endif()
+set(LEMON_DEFAULT_MIP "${_default_mip}" CACHE STRING
+  "Default MIP solver backend (GLPK, CPLEX or CBC)"
+  FORCE)
+
+unset(_default_lp)
+unset(_default_mip)
+unset(_lp_needs_reset)
+unset(_mip_needs_reset)
+
+# ---------------------------------------------------------------------------
+# Compiler warning flags
+# ---------------------------------------------------------------------------
+if(DEFINED ENV{LEMON_CXX_WARNING})
+  # La variable d'env est une string — separate_arguments la découpe en liste CMake
+  separate_arguments(_cxx_warning_list UNIX_COMMAND "$ENV{LEMON_CXX_WARNING}")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  # Chaque flag est un élément de liste séparé : pas de string(JOIN), pas de quotes
+  set(_cxx_warning_list
+    -Wall
+    -Wextra
+    -Wunused
+    -Wformat=2
+    -Wctor-dtor-privacy
+    -Wnon-virtual-dtor
+    -Wno-char-subscripts
+    -Wwrite-strings
+    -Wreturn-type
+    -Wcast-qual
+    -Wcast-align
+    -Wsign-promo
+    -Woverloaded-virtual
+    -fno-strict-aliasing
+    -Wold-style-cast
+    -Wno-unknown-pragmas
   )
-  EXECUTE_PROCESS(
-    COMMAND
-    hg log -r. --template "{node|short}"
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-    OUTPUT_VARIABLE HG_REVISION_ID
-    ERROR_QUIET
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
+elseif(MSVC)
+  # C4250: inherits via dominance  C4355: 'this' in initializer list
+  # C4503: name truncated           C4800: bool coercion perf warning
+  # C4996: deprecated function
+  set(_cxx_warning_list /wd4250 /wd4355 /wd4503 /wd4800 /wd4996)
+else()
+  set(_cxx_warning_list -Wall)
+endif()
 
-  IF(HG_REVISION_TAG STREQUAL "")
-    SET(HG_REVISION_ID "hg-tip")
-  ELSE()
-    IF(HG_REVISION_TAG STREQUAL "null")
-      SET(HG_REVISION_TAG "trunk")
-    ELSEIF(HG_REVISION_TAG MATCHES "^r")
-      STRING(SUBSTRING ${HG_REVISION_TAG} 1 -1 HG_REVISION_TAG)
-    ENDIF()
-    IF(HG_REVISION_DIST STREQUAL "0")
-      SET(HG_REVISION ${HG_REVISION_TAG})
-    ELSE()
-      SET(HG_REVISION
-	"${HG_REVISION_TAG}+${HG_REVISION_DIST}-${HG_REVISION_ID}")
-    ENDIF()
-  ENDIF()
+# Cache : string lisible dans cmake-gui / ccmake
+string(JOIN " " LEMON_CXX_WARNING_FLAGS ${_cxx_warning_list})
+set(LEMON_CXX_WARNING_FLAGS "${LEMON_CXX_WARNING_FLAGS}"
+  CACHE STRING "LEMON warning flags.")
 
-  SET(LEMON_VERSION ${HG_REVISION} CACHE STRING "LEMON version string.")
-ENDIF()
+# Interface target — transporte la liste de flags (éléments séparés, pas une string)
+add_library(lemon_warnings INTERFACE)
+target_compile_options(lemon_warnings INTERFACE
+  $<BUILD_INTERFACE:${_cxx_warning_list}>
+)
+unset(_cxx_warning_list)
 
-SET(PROJECT_VERSION ${LEMON_VERSION})
+# ---------------------------------------------------------------------------
+# Build type & Maintainer configuration
+# ---------------------------------------------------------------------------
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING
+    "Build type: None Debug Release RelWithDebInfo MinSizeRel Maintainer." FORCE)
+endif()
 
-SET(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+if(MSVC)
+  set(_maintainer_cxx  "/WX ${CMAKE_CXX_FLAGS_DEBUG}")
+  set(_maintainer_c    "/WX ${CMAKE_C_FLAGS_DEBUG}")
+else()
+  set(_maintainer_cxx  "-Werror -ggdb -O0")
+  set(_maintainer_c    "-Werror -O0")
+endif()
 
-FIND_PACKAGE(Doxygen)
-FIND_PACKAGE(Ghostscript)
+set(CMAKE_CXX_FLAGS_MAINTAINER    "${_maintainer_cxx}"
+  CACHE STRING "C++ flags for maintainer builds." FORCE)
+set(CMAKE_C_FLAGS_MAINTAINER      "${_maintainer_c}"
+  CACHE STRING "C flags for maintainer builds."   FORCE)
+set(CMAKE_EXE_LINKER_FLAGS_MAINTAINER
+  "${CMAKE_EXE_LINKER_FLAGS_DEBUG}"
+  CACHE STRING "Linker flags for maintainer builds." FORCE)
+set(CMAKE_SHARED_LINKER_FLAGS_MAINTAINER
+  "${CMAKE_SHARED_LINKER_FLAGS_DEBUG}"
+  CACHE STRING "Shared linker flags for maintainer builds." FORCE)
 
-SET(LEMON_ENABLE_GLPK YES CACHE STRING "Enable GLPK solver backend.")
-SET(LEMON_ENABLE_ILOG YES CACHE STRING "Enable ILOG (CPLEX) solver backend.")
-SET(LEMON_ENABLE_COIN YES CACHE STRING "Enable COIN solver backend.")
-SET(LEMON_ENABLE_SOPLEX YES CACHE STRING "Enable SoPlex solver backend.")
+mark_as_advanced(
+  CMAKE_CXX_FLAGS_MAINTAINER
+  CMAKE_C_FLAGS_MAINTAINER
+  CMAKE_EXE_LINKER_FLAGS_MAINTAINER
+  CMAKE_SHARED_LINKER_FLAGS_MAINTAINER
+)
 
-IF(LEMON_ENABLE_GLPK) 
-  FIND_PACKAGE(GLPK 4.33)
-ENDIF(LEMON_ENABLE_GLPK)
-IF(LEMON_ENABLE_ILOG)
-  FIND_PACKAGE(ILOG)
-ENDIF(LEMON_ENABLE_ILOG)
-IF(LEMON_ENABLE_COIN)
-  FIND_PACKAGE(COIN)
-ENDIF(LEMON_ENABLE_COIN)
-IF(LEMON_ENABLE_SOPLEX)
-  FIND_PACKAGE(SOPLEX)
-ENDIF(LEMON_ENABLE_SOPLEX)
+if(CMAKE_CONFIGURATION_TYPES)
+  list(APPEND CMAKE_CONFIGURATION_TYPES Maintainer)
+  list(REMOVE_DUPLICATES CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_CONFIGURATION_TYPES "${CMAKE_CONFIGURATION_TYPES}"
+    CACHE STRING "Available build configurations." FORCE)
+endif()
 
-IF(GLPK_FOUND)
-  SET(LEMON_HAVE_LP TRUE)
-  SET(LEMON_HAVE_MIP TRUE)
-  SET(LEMON_HAVE_GLPK TRUE)
-ENDIF(GLPK_FOUND)
-IF(ILOG_FOUND)
-  SET(LEMON_HAVE_LP TRUE)
-  SET(LEMON_HAVE_MIP TRUE)
-  SET(LEMON_HAVE_CPLEX TRUE)
-ENDIF(ILOG_FOUND)
-IF(COIN_FOUND)
-  SET(LEMON_HAVE_LP TRUE)
-  SET(LEMON_HAVE_MIP TRUE)
-  SET(LEMON_HAVE_CLP TRUE)
-  SET(LEMON_HAVE_CBC TRUE)
-ENDIF(COIN_FOUND)
-IF(SOPLEX_FOUND)
-  SET(LEMON_HAVE_LP TRUE)
-  SET(LEMON_HAVE_SOPLEX TRUE)
-ENDIF(SOPLEX_FOUND)
+unset(_maintainer_cxx)
+unset(_maintainer_c)
 
-IF(ILOG_FOUND)
-  SET(DEFAULT_LP "CPLEX")
-  SET(DEFAULT_MIP "CPLEX")
-ELSEIF(COIN_FOUND)
-  SET(DEFAULT_LP "CLP")
-  SET(DEFAULT_MIP "CBC")
-ELSEIF(GLPK_FOUND)
-  SET(DEFAULT_LP "GLPK")
-  SET(DEFAULT_MIP "GLPK")
-ELSEIF(SOPLEX_FOUND)
-  SET(DEFAULT_LP "SOPLEX")
-ENDIF()
+# ---------------------------------------------------------------------------
+# Platform / type introspection
+# ---------------------------------------------------------------------------
+include(CheckTypeSize)
+check_type_size("long long" LONG_LONG)
+set(LEMON_HAVE_LONG_LONG ${HAVE_LONG_LONG})
 
-IF(NOT LEMON_DEFAULT_LP OR
-    (NOT ILOG_FOUND AND (LEMON_DEFAULT_LP STREQUAL "CPLEX")) OR
-    (NOT COIN_FOUND AND (LEMON_DEFAULT_LP STREQUAL "CLP")) OR
-    (NOT GLPK_FOUND AND (LEMON_DEFAULT_LP STREQUAL "GLPK")) OR
-    (NOT SOPLEX_FOUND AND (LEMON_DEFAULT_LP STREQUAL "SOPLEX")))
-  SET(LEMON_DEFAULT_LP ${DEFAULT_LP} CACHE STRING
-    "Default LP solver backend (GLPK, CPLEX, CLP or SOPLEX)" FORCE)
-ELSE()
-  SET(LEMON_DEFAULT_LP ${DEFAULT_LP} CACHE STRING
-    "Default LP solver backend (GLPK, CPLEX, CLP or SOPLEX)")
-ENDIF()
-IF(NOT LEMON_DEFAULT_MIP OR
-    (NOT ILOG_FOUND AND (LEMON_DEFAULT_MIP STREQUAL "CPLEX")) OR
-    (NOT COIN_FOUND AND (LEMON_DEFAULT_MIP STREQUAL "CBC")) OR
-    (NOT GLPK_FOUND AND (LEMON_DEFAULT_MIP STREQUAL "GLPK")))
-  SET(LEMON_DEFAULT_MIP ${DEFAULT_MIP} CACHE STRING
-    "Default MIP solver backend (GLPK, CPLEX or CBC)" FORCE)
-ELSE()
-  SET(LEMON_DEFAULT_MIP ${DEFAULT_MIP} CACHE STRING
-    "Default MIP solver backend (GLPK, CPLEX or CBC)")
-ENDIF()
+find_package(Threads QUIET)
 
+if(NOT LEMON_THREADING)
+  if(CMAKE_USE_PTHREADS_INIT)
+    set(LEMON_THREADING "Pthread")
+  elseif(CMAKE_USE_WIN32_THREADS_INIT)
+    set(LEMON_THREADING "Win32")
+  else()
+    set(LEMON_THREADING "None")
+  endif()
+endif()
 
-IF(DEFINED ENV{LEMON_CXX_WARNING})
-  SET(CXX_WARNING $ENV{LEMON_CXX_WARNING})
-ELSE()
-  IF(CMAKE_COMPILER_IS_GNUCXX)
-    SET(CXX_WARNING "-Wall -W -Wunused -Wformat=2 -Wctor-dtor-privacy -Wnon-virtual-dtor -Wno-char-subscripts -Wwrite-strings -Wno-char-subscripts -Wreturn-type -Wcast-qual -Wcast-align -Wsign-promo -Woverloaded-virtual -fno-strict-aliasing -Wold-style-cast -Wno-unknown-pragmas")
-    SET(CMAKE_CXX_FLAGS_DEBUG CACHE STRING "-ggdb")
-    SET(CMAKE_C_FLAGS_DEBUG CACHE STRING "-ggdb")
-  ELSEIF(MSVC)
-    # This part is unnecessary 'casue the same is set by the lemon/core.h.
-    # Still keep it as an example.
-    SET(CXX_WARNING "/wd4250 /wd4355 /wd4503 /wd4800 /wd4996")
-    # Suppressed warnings:
-    # C4250: 'class1' : inherits 'class2::member' via dominance
-    # C4355: 'this' : used in base member initializer list
-    # C4503: 'function' : decorated name length exceeded, name was truncated
-    # C4800: 'type' : forcing value to bool 'true' or 'false'
-    #        (performance warning)
-    # C4996: 'function': was declared deprecated
-  ELSE()
-    SET(CXX_WARNING "-Wall")
-  ENDIF()
-ENDIF()
-SET(LEMON_CXX_WARNING_FLAGS ${CXX_WARNING} CACHE STRING "LEMON warning flags.")
+set(LEMON_THREADING "${LEMON_THREADING}" CACHE STRING
+  "Threading library: Pthread | Win32 | None." FORCE)
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${LEMON_CXX_WARNING_FLAGS}")
+if(LEMON_THREADING STREQUAL "Pthread")
+  set(LEMON_USE_PTHREAD TRUE)
+elseif(LEMON_THREADING STREQUAL "Win32")
+  set(LEMON_USE_WIN32_THREADS TRUE)
+endif()
 
-IF(MSVC)
-  SET( CMAKE_CXX_FLAGS_MAINTAINER "/WX ${CMAKE_CXX_FLAGS_DEBUG}" CACHE STRING
-    "Flags used by the C++ compiler during maintainer builds."
-    )
-  SET( CMAKE_C_FLAGS_MAINTAINER "/WX ${CMAKE_CXX_FLAGS_DEBUG}" CACHE STRING
-    "Flags used by the C compiler during maintainer builds."
-    )
-  SET( CMAKE_EXE_LINKER_FLAGS_MAINTAINER
-    "${CMAKE_EXE_LINKER_FLAGS_DEBUG}" CACHE STRING
-    "Flags used for linking binaries during maintainer builds."
-    )
-  SET( CMAKE_SHARED_LINKER_FLAGS_MAINTAINER
-    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG}" CACHE STRING
-    "Flags used by the shared libraries linker during maintainer builds."
-    )
-ELSE()
-  SET( CMAKE_CXX_FLAGS_MAINTAINER "-Werror -ggdb -O0" CACHE STRING
-    "Flags used by the C++ compiler during maintainer builds."
-    )
-  SET( CMAKE_C_FLAGS_MAINTAINER "-Werror -O0" CACHE STRING
-    "Flags used by the C compiler during maintainer builds."
-    )
-  SET( CMAKE_EXE_LINKER_FLAGS_MAINTAINER
-    "${CMAKE_EXE_LINKER_FLAGS_DEBUG}" CACHE STRING
-    "Flags used for linking binaries during maintainer builds."
-    )
-  SET( CMAKE_SHARED_LINKER_FLAGS_MAINTAINER
-    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG}" CACHE STRING
-    "Flags used by the shared libraries linker during maintainer builds."
-    )
-ENDIF()
+# ---------------------------------------------------------------------------
+# Testing
+# ---------------------------------------------------------------------------
+enable_testing()
 
-MARK_AS_ADVANCED(
-    CMAKE_CXX_FLAGS_MAINTAINER
-    CMAKE_C_FLAGS_MAINTAINER
-    CMAKE_EXE_LINKER_FLAGS_MAINTAINER
-    CMAKE_SHARED_LINKER_FLAGS_MAINTAINER )
+if(CMAKE_BUILD_TYPE STREQUAL "Maintainer")
+  add_custom_target(check ALL COMMAND ${CMAKE_CTEST_COMMAND})
+else()
+  add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+endif()
 
-IF(CMAKE_CONFIGURATION_TYPES)
-  LIST(APPEND CMAKE_CONFIGURATION_TYPES Maintainer)
-  LIST(REMOVE_DUPLICATES CMAKE_CONFIGURATION_TYPES)
-  SET(CMAKE_CONFIGURATION_TYPES "${CMAKE_CONFIGURATION_TYPES}" CACHE STRING
-      "Add the configurations that we need"
-      FORCE)
- endif()
+# ---------------------------------------------------------------------------
+# Sub-directories
+# ---------------------------------------------------------------------------
+add_subdirectory(lemon)
 
-IF(NOT CMAKE_BUILD_TYPE)
-  SET(CMAKE_BUILD_TYPE "Release")
-ENDIF()
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+  add_subdirectory(contrib)
+  add_subdirectory(demo)
+  add_subdirectory(tools)
+  add_subdirectory(doc)
+  add_subdirectory(test)
+endif()
 
-SET( CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE STRING
-    "Choose the type of build, options are: None(CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel Maintainer."
-    FORCE )
+# ---------------------------------------------------------------------------
+# CMake config file installation
+# ---------------------------------------------------------------------------
+include(GNUInstallDirs)
 
-
-INCLUDE(CheckTypeSize)
-CHECK_TYPE_SIZE("long long" LONG_LONG)
-SET(LEMON_HAVE_LONG_LONG ${HAVE_LONG_LONG})
-
-INCLUDE(FindThreads)
-
-IF(NOT LEMON_THREADING)
-  IF(CMAKE_USE_PTHREADS_INIT)
-    SET(LEMON_THREADING "Pthread")
-  ELSEIF(CMAKE_USE_WIN32_THREADS_INIT)
-    SET(LEMON_THREADING "Win32")
-  ELSE()
-    SET(LEMON_THREADING "None")
-  ENDIF()
-ENDIF()
-
-SET( LEMON_THREADING "${LEMON_THREADING}" CACHE STRING
-  "Choose the threading library, options are: Pthread Win32 None."
-  FORCE )
-
-IF(LEMON_THREADING STREQUAL "Pthread")
-  SET(LEMON_USE_PTHREAD TRUE)
-ELSEIF(LEMON_THREADING STREQUAL "Win32")
-  SET(LEMON_USE_WIN32_THREADS TRUE)
-ENDIF()
-
-ENABLE_TESTING()
-
-IF(${CMAKE_BUILD_TYPE} STREQUAL "Maintainer")
-  ADD_CUSTOM_TARGET(check ALL COMMAND ${CMAKE_CTEST_COMMAND})
-ELSE()
-  ADD_CUSTOM_TARGET(check COMMAND ${CMAKE_CTEST_COMMAND})
-ENDIF()
-
-ADD_SUBDIRECTORY(lemon)
-IF(${CMAKE_SOURCE_DIR} STREQUAL ${PROJECT_SOURCE_DIR})
-  ADD_SUBDIRECTORY(contrib)
-  ADD_SUBDIRECTORY(demo)
-  ADD_SUBDIRECTORY(tools)
-  ADD_SUBDIRECTORY(doc)
-  ADD_SUBDIRECTORY(test)
-ENDIF()
-
-CONFIGURE_FILE(
-  ${PROJECT_SOURCE_DIR}/cmake/LEMONConfig.cmake.in
-  ${PROJECT_BINARY_DIR}/cmake/LEMONConfig.cmake
+configure_file(
+  "${PROJECT_SOURCE_DIR}/cmake/LEMONConfig.cmake.in"
+  "${PROJECT_BINARY_DIR}/cmake/LEMONConfig.cmake"
   @ONLY
 )
-IF(UNIX)
-  INSTALL(
-    FILES ${PROJECT_BINARY_DIR}/cmake/LEMONConfig.cmake
+
+if(UNIX)
+  install(
+    FILES "${PROJECT_BINARY_DIR}/cmake/LEMONConfig.cmake"
     DESTINATION share/lemon/cmake
   )
-ELSEIF(WIN32)
-  INSTALL(
-    FILES ${PROJECT_BINARY_DIR}/cmake/LEMONConfig.cmake
+elseif(WIN32)
+  install(
+    FILES "${PROJECT_BINARY_DIR}/cmake/LEMONConfig.cmake"
     DESTINATION cmake
   )
-ENDIF()
+endif()
 
-CONFIGURE_FILE(
-  ${PROJECT_SOURCE_DIR}/cmake/version.cmake.in
-  ${PROJECT_BINARY_DIR}/cmake/version.cmake
+configure_file(
+  "${PROJECT_SOURCE_DIR}/cmake/version.cmake.in"
+  "${PROJECT_BINARY_DIR}/cmake/version.cmake"
   @ONLY
 )
 
-SET(ARCHIVE_BASE_NAME ${CMAKE_PROJECT_NAME})
-STRING(TOLOWER ${ARCHIVE_BASE_NAME} ARCHIVE_BASE_NAME)
-SET(ARCHIVE_NAME ${ARCHIVE_BASE_NAME}-${PROJECT_VERSION})
-ADD_CUSTOM_TARGET(dist
-  COMMAND cmake -E remove_directory ${ARCHIVE_NAME}
-  COMMAND hg archive ${ARCHIVE_NAME}
-  COMMAND cmake -E copy cmake/version.cmake ${ARCHIVE_NAME}/cmake/version.cmake
-  COMMAND tar -czf ${ARCHIVE_BASE_NAME}-nodoc-${PROJECT_VERSION}.tar.gz ${ARCHIVE_NAME}
-  COMMAND zip -r ${ARCHIVE_BASE_NAME}-nodoc-${PROJECT_VERSION}.zip ${ARCHIVE_NAME}
-  COMMAND cmake -E copy_directory doc/html ${ARCHIVE_NAME}/doc/html
-  COMMAND tar -czf ${ARCHIVE_NAME}.tar.gz ${ARCHIVE_NAME}
-  COMMAND zip -r ${ARCHIVE_NAME}.zip ${ARCHIVE_NAME}
-  COMMAND cmake -E copy_directory doc/html ${ARCHIVE_BASE_NAME}-doc-${PROJECT_VERSION}
-  COMMAND tar -czf ${ARCHIVE_BASE_NAME}-doc-${PROJECT_VERSION}.tar.gz ${ARCHIVE_BASE_NAME}-doc-${PROJECT_VERSION}
-  COMMAND zip -r ${ARCHIVE_BASE_NAME}-doc-${PROJECT_VERSION}.zip ${ARCHIVE_BASE_NAME}-doc-${PROJECT_VERSION}
-  COMMAND cmake -E remove_directory ${ARCHIVE_NAME}
-  COMMAND cmake -E remove_directory ${ARCHIVE_BASE_NAME}-doc-${PROJECT_VERSION}
+# ---------------------------------------------------------------------------
+# Source archive target (git-based, no hg)
+# ---------------------------------------------------------------------------
+string(TOLOWER "${PROJECT_NAME}" _archive_base)
+set(_archive_name "${_archive_base}-${PROJECT_VERSION}")
+
+add_custom_target(dist
+  COMMAND ${CMAKE_COMMAND} -E remove_directory "${_archive_name}"
+  COMMAND git archive --prefix="${_archive_name}/" --format=tar HEAD
+          | tar -x
+  COMMAND ${CMAKE_COMMAND} -E copy
+          cmake/version.cmake "${_archive_name}/cmake/version.cmake"
+  COMMAND tar -czf "${_archive_base}-nodoc-${PROJECT_VERSION}.tar.gz" "${_archive_name}"
+  COMMAND zip  -r  "${_archive_base}-nodoc-${PROJECT_VERSION}.zip"    "${_archive_name}"
+  COMMAND ${CMAKE_COMMAND} -E copy_directory doc/html "${_archive_name}/doc/html"
+  COMMAND tar -czf "${_archive_name}.tar.gz" "${_archive_name}"
+  COMMAND zip  -r  "${_archive_name}.zip"    "${_archive_name}"
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+          doc/html "${_archive_base}-doc-${PROJECT_VERSION}"
+  COMMAND tar -czf "${_archive_base}-doc-${PROJECT_VERSION}.tar.gz"
+          "${_archive_base}-doc-${PROJECT_VERSION}"
+  COMMAND zip  -r  "${_archive_base}-doc-${PROJECT_VERSION}.zip"
+          "${_archive_base}-doc-${PROJECT_VERSION}"
+  COMMAND ${CMAKE_COMMAND} -E remove_directory "${_archive_name}"
+  COMMAND ${CMAKE_COMMAND} -E remove_directory "${_archive_base}-doc-${PROJECT_VERSION}"
   DEPENDS html
-  WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+  WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
+)
 
-# CPACK config (Basically for NSIS)
-IF(${CMAKE_SOURCE_DIR} STREQUAL ${PROJECT_SOURCE_DIR})
-  SET(CPACK_PACKAGE_NAME ${PROJECT_NAME})
-  SET(CPACK_PACKAGE_VENDOR "EGRES")
-  SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY
+unset(_archive_base)
+unset(_archive_name)
+
+# ---------------------------------------------------------------------------
+# CPack / NSIS (top-level build only)
+# ---------------------------------------------------------------------------
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+  set(CPACK_PACKAGE_NAME                 "${PROJECT_NAME}")
+  set(CPACK_PACKAGE_VENDOR               "EGRES")
+  set(CPACK_PACKAGE_DESCRIPTION_SUMMARY
     "LEMON - Library for Efficient Modeling and Optimization in Networks")
-  SET(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
+  set(CPACK_RESOURCE_FILE_LICENSE        "${PROJECT_SOURCE_DIR}/LICENSE")
+  set(CPACK_PACKAGE_VERSION              "${PROJECT_VERSION}")
+  set(CPACK_PACKAGE_INSTALL_DIRECTORY    "${PROJECT_NAME} ${PROJECT_VERSION}")
+  set(CPACK_PACKAGE_INSTALL_REGISTRY_KEY "${PROJECT_NAME} ${PROJECT_VERSION}")
 
-  SET(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
+  set(CPACK_COMPONENTS_ALL headers library html_documentation bin)
 
-  SET(CPACK_PACKAGE_INSTALL_DIRECTORY
-    "${PROJECT_NAME} ${PROJECT_VERSION}")
-  SET(CPACK_PACKAGE_INSTALL_REGISTRY_KEY
-    "${PROJECT_NAME} ${PROJECT_VERSION}")
+  set(CPACK_COMPONENT_HEADERS_DISPLAY_NAME          "C++ headers")
+  set(CPACK_COMPONENT_LIBRARY_DISPLAY_NAME           "Dynamic-link library")
+  set(CPACK_COMPONENT_BIN_DISPLAY_NAME               "Command line utilities")
+  set(CPACK_COMPONENT_HTML_DOCUMENTATION_DISPLAY_NAME "HTML documentation")
 
-  SET(CPACK_COMPONENTS_ALL headers library html_documentation bin)
+  set(CPACK_COMPONENT_HEADERS_DESCRIPTION            "C++ header files")
+  set(CPACK_COMPONENT_LIBRARY_DESCRIPTION            "DLL and import library")
+  set(CPACK_COMPONENT_BIN_DESCRIPTION                "Command line utilities")
+  set(CPACK_COMPONENT_HTML_DOCUMENTATION_DESCRIPTION "Doxygen generated documentation")
 
-  SET(CPACK_COMPONENT_HEADERS_DISPLAY_NAME "C++ headers")
-  SET(CPACK_COMPONENT_LIBRARY_DISPLAY_NAME "Dynamic-link library")
-  SET(CPACK_COMPONENT_BIN_DISPLAY_NAME "Command line utilities")
-  SET(CPACK_COMPONENT_HTML_DOCUMENTATION_DISPLAY_NAME "HTML documentation")
+  set(CPACK_COMPONENT_HEADERS_DEPENDS  library)
+  set(CPACK_COMPONENT_HEADERS_GROUP    "Development")
+  set(CPACK_COMPONENT_LIBRARY_GROUP    "Development")
+  set(CPACK_COMPONENT_HTML_DOCUMENTATION_GROUP "Documentation")
 
-  SET(CPACK_COMPONENT_HEADERS_DESCRIPTION
-    "C++ header files")
-  SET(CPACK_COMPONENT_LIBRARY_DESCRIPTION
-    "DLL and import library")
-  SET(CPACK_COMPONENT_BIN_DESCRIPTION
-    "Command line utilities")
-  SET(CPACK_COMPONENT_HTML_DOCUMENTATION_DESCRIPTION
-    "Doxygen generated documentation")
-
-  SET(CPACK_COMPONENT_HEADERS_DEPENDS library)
-
-  SET(CPACK_COMPONENT_HEADERS_GROUP "Development")
-  SET(CPACK_COMPONENT_LIBRARY_GROUP "Development")
-  SET(CPACK_COMPONENT_HTML_DOCUMENTATION_GROUP "Documentation")
-
-  SET(CPACK_COMPONENT_GROUP_DEVELOPMENT_DESCRIPTION
+  set(CPACK_COMPONENT_GROUP_DEVELOPMENT_DESCRIPTION
     "Components needed to develop software using LEMON")
-  SET(CPACK_COMPONENT_GROUP_DOCUMENTATION_DESCRIPTION
+  set(CPACK_COMPONENT_GROUP_DOCUMENTATION_DESCRIPTION
     "Documentation of LEMON")
 
-  SET(CPACK_ALL_INSTALL_TYPES Full Developer)
+  set(CPACK_ALL_INSTALL_TYPES Full Developer)
+  set(CPACK_COMPONENT_HEADERS_INSTALL_TYPES          Developer Full)
+  set(CPACK_COMPONENT_LIBRARY_INSTALL_TYPES          Developer Full)
+  set(CPACK_COMPONENT_HTML_DOCUMENTATION_INSTALL_TYPES Full)
 
-  SET(CPACK_COMPONENT_HEADERS_INSTALL_TYPES Developer Full)
-  SET(CPACK_COMPONENT_LIBRARY_INSTALL_TYPES Developer Full)
-  SET(CPACK_COMPONENT_HTML_DOCUMENTATION_INSTALL_TYPES Full)
+  set(CPACK_GENERATOR             "NSIS")
+  set(CPACK_NSIS_MUI_ICON         "${PROJECT_SOURCE_DIR}/cmake/nsis/lemon.ico")
+  set(CPACK_NSIS_MUI_UNIICON      "${PROJECT_SOURCE_DIR}/cmake/nsis/uninstall.ico")
+  set(CPACK_NSIS_INSTALLED_ICON_NAME "bin\\\\lemon.ico")
+  set(CPACK_NSIS_DISPLAY_NAME     "${CPACK_PACKAGE_INSTALL_DIRECTORY} ${PROJECT_NAME}")
+  set(CPACK_NSIS_HELP_LINK        "http:\\\\\\\\lemon.cs.elte.hu")
+  set(CPACK_NSIS_URL_INFO_ABOUT   "http:\\\\\\\\lemon.cs.elte.hu")
+  set(CPACK_NSIS_CONTACT          "lemon-user@lemon.cs.elte.hu")
+  set(CPACK_NSIS_CREATE_ICONS_EXTRA
+    "CreateShortCut \\\"$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\Documentation.lnk\\\" \
+\\\"$INSTDIR\\\\share\\\\doc\\\\index.html\\\"")
+  set(CPACK_NSIS_DELETE_ICONS_EXTRA
+    "!insertmacro MUI_STARTMENU_GETFOLDER Application $MUI_TEMP\n\
+    Delete \\\"$SMPROGRAMS\\\\$MUI_TEMP\\\\Documentation.lnk\\\"")
 
-  SET(CPACK_GENERATOR "NSIS")
-  SET(CPACK_NSIS_MUI_ICON "${PROJECT_SOURCE_DIR}/cmake/nsis/lemon.ico")
-  SET(CPACK_NSIS_MUI_UNIICON "${PROJECT_SOURCE_DIR}/cmake/nsis/uninstall.ico")
-  #SET(CPACK_PACKAGE_ICON "${PROJECT_SOURCE_DIR}/cmake/nsis\\\\installer.bmp")
-  SET(CPACK_NSIS_INSTALLED_ICON_NAME "bin\\\\lemon.ico")
-  SET(CPACK_NSIS_DISPLAY_NAME "${CPACK_PACKAGE_INSTALL_DIRECTORY} ${PROJECT_NAME}")
-  SET(CPACK_NSIS_HELP_LINK "http:\\\\\\\\lemon.cs.elte.hu")
-  SET(CPACK_NSIS_URL_INFO_ABOUT "http:\\\\\\\\lemon.cs.elte.hu")
-  SET(CPACK_NSIS_CONTACT "lemon-user@lemon.cs.elte.hu")
-  SET(CPACK_NSIS_CREATE_ICONS_EXTRA "
-    CreateShortCut \\\"$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\Documentation.lnk\\\" \\\"$INSTDIR\\\\share\\\\doc\\\\index.html\\\"
-    ")
-  SET(CPACK_NSIS_DELETE_ICONS_EXTRA "
-    !insertmacro MUI_STARTMENU_GETFOLDER Application $MUI_TEMP
-    Delete \\\"$SMPROGRAMS\\\\$MUI_TEMP\\\\Documentation.lnk\\\"
-    ")
-
-  INCLUDE(CPack)
-ENDIF()
+  include(CPack)
+endif()

--- a/cmake/LEMONConfig.cmake.in
+++ b/cmake/LEMONConfig.cmake.in
@@ -1,13 +1,177 @@
-SET(LEMON_INCLUDE_DIR "@CMAKE_INSTALL_PREFIX@/include" CACHE PATH "LEMON include directory")
-SET(LEMON_INCLUDE_DIRS "${LEMON_INCLUDE_DIR}")
+# ---------------------------------------------------------------------------
+# lemon/CMakeLists.txt
+# ---------------------------------------------------------------------------
 
-IF(UNIX)
-  SET(LEMON_LIB_NAME "libemon.a")
-ELSEIF(WIN32)
-  SET(LEMON_LIB_NAME "lemon.lib")
-ENDIF(UNIX)
+# ---------------------------------------------------------------------------
+# Configure generated headers
+# ---------------------------------------------------------------------------
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/config.h.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/config.h"
+)
 
-SET(LEMON_LIBRARY "@CMAKE_INSTALL_PREFIX@/lib/${LEMON_LIB_NAME}" CACHE FILEPATH "LEMON library")
-SET(LEMON_LIBRARIES "${LEMON_LIBRARY}")
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/lemon.pc.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/lemon.pc"
+  @ONLY
+)
 
-MARK_AS_ADVANCED(LEMON_LIBRARY LEMON_INCLUDE_DIR)
+# ---------------------------------------------------------------------------
+# Sources
+# ---------------------------------------------------------------------------
+set(LEMON_SOURCES
+  arg_parser.cc
+  base.cc
+  color.cc
+  lp_base.cc
+  lp_skeleton.cc
+  random.cc
+  bits/windows.cc
+)
+
+if(LEMON_HAVE_GLPK)
+  list(APPEND LEMON_SOURCES glpk.cc)
+endif()
+if(LEMON_HAVE_CPLEX)
+  list(APPEND LEMON_SOURCES cplex.cc)
+endif()
+if(LEMON_HAVE_CLP)
+  list(APPEND LEMON_SOURCES clp.cc)
+endif()
+if(LEMON_HAVE_CBC)
+  list(APPEND LEMON_SOURCES cbc.cc)
+endif()
+if(LEMON_HAVE_SOPLEX)
+  list(APPEND LEMON_SOURCES soplex.cc)
+endif()
+
+# ---------------------------------------------------------------------------
+# Library type  (contrôlé par BUILD_SHARED_LIBS, standard CMake)
+#   cmake -DBUILD_SHARED_LIBS=ON  ...   → shared (.so / .dll)
+#   cmake -DBUILD_SHARED_LIBS=OFF ...   → static (.a / .lib)  [défaut]
+# ---------------------------------------------------------------------------
+add_library(lemon ${LEMON_SOURCES})
+
+# Alias pour que les consumers internes utilisent le même nom que l'extérieur
+add_library(LEMON::lemon ALIAS lemon)
+
+# ---------------------------------------------------------------------------
+# Export header (visibilité DLL sur Windows, no-op sur Linux/macOS)
+# Génère lemon/lemon_export.h dans le build dir
+# ---------------------------------------------------------------------------
+include(GenerateExportHeader)
+generate_export_header(lemon
+  BASE_NAME         LEMON
+  EXPORT_MACRO_NAME LEMON_API
+  EXPORT_FILE_NAME  "${CMAKE_CURRENT_BINARY_DIR}/lemon_export.h"
+)
+
+# ---------------------------------------------------------------------------
+# Propriétés de la cible
+# ---------------------------------------------------------------------------
+set_target_properties(lemon PROPERTIES
+  OUTPUT_NAME   "emon"
+  VERSION       "${PROJECT_VERSION}"
+  SOVERSION     "${PROJECT_VERSION_MAJOR}"        # ABI : majeur seulement
+  # Position-independent code : obligatoire pour les .so, inutile mais
+  # inoffensif pour les .a — on l'active toujours pour simplifier
+  POSITION_INDEPENDENT_CODE ON
+  # Visibilité par défaut = hidden → seuls les symboles LEMON_API sont exportés
+  CXX_VISIBILITY_PRESET     hidden
+  VISIBILITY_INLINES_HIDDEN ON
+)
+
+# ---------------------------------------------------------------------------
+# Includes
+# ---------------------------------------------------------------------------
+target_include_directories(lemon
+  PUBLIC
+    # consumers (build tree)
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>   # config.h + lemon_export.h
+    # consumers (install tree)
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  PRIVATE
+    # solvers — uniquement nécessaires lors de la compilation de lemon lui-même
+    $<$<BOOL:${LEMON_HAVE_GLPK}>:${GLPK_INCLUDE_DIRS}>
+    $<$<BOOL:${LEMON_HAVE_CPLEX}>:${ILOG_INCLUDE_DIRS}>
+    $<$<BOOL:${LEMON_HAVE_CLP}>:${COIN_INCLUDE_DIRS}>
+    $<$<BOOL:${LEMON_HAVE_CBC}>:${COIN_INCLUDE_DIRS}>
+    $<$<BOOL:${LEMON_HAVE_SOPLEX}>:${SOPLEX_INCLUDE_DIRS}>
+)
+
+# ---------------------------------------------------------------------------
+# Link
+# ---------------------------------------------------------------------------
+target_link_libraries(lemon
+  PRIVATE
+    lemon_warnings
+    $<$<BOOL:${GLPK_LIBRARIES}>:${GLPK_LIBRARIES}>
+    $<$<BOOL:${COIN_LIBRARIES}>:${COIN_LIBRARIES}>
+    $<$<BOOL:${ILOG_LIBRARIES}>:${ILOG_LIBRARIES}>
+    $<$<BOOL:${SOPLEX_LIBRARIES}>:${SOPLEX_LIBRARIES}>
+    $<$<BOOL:${LEMON_USE_PTHREAD}>:Threads::Threads>
+)
+
+# ---------------------------------------------------------------------------
+# Install — cible
+# ---------------------------------------------------------------------------
+install(
+  TARGETS lemon
+  EXPORT  LEMONTargets
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"   COMPONENT library
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"   COMPONENT library
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"   COMPONENT library  # .dll Windows
+)
+
+# ---------------------------------------------------------------------------
+# Install — headers publics
+# ---------------------------------------------------------------------------
+install(
+  DIRECTORY
+    "${CMAKE_CURRENT_SOURCE_DIR}/"
+    "${CMAKE_CURRENT_SOURCE_DIR}/bits"
+    "${CMAKE_CURRENT_SOURCE_DIR}/concepts"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/lemon"
+  COMPONENT   headers
+  FILES_MATCHING PATTERN "*.h"
+)
+
+install(
+  FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/config.h"
+    "${CMAKE_CURRENT_BINARY_DIR}/lemon_export.h"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/lemon"
+  COMPONENT   headers
+)
+
+# ---------------------------------------------------------------------------
+# Install — pkg-config
+# ---------------------------------------------------------------------------
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/lemon.pc"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+)
+
+# ---------------------------------------------------------------------------
+# Install — export set (consommé par LEMONConfig.cmake)
+# ---------------------------------------------------------------------------
+install(
+  EXPORT      LEMONTargets
+  NAMESPACE   LEMON::
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/lemon/cmake"
+  COMPONENT   headers
+)
+
+# ---------------------------------------------------------------------------
+# DLL Windows : copie des DLL tierces
+# ---------------------------------------------------------------------------
+if(WIN32 AND LEMON_HAVE_GLPK)
+  install(FILES
+    "${GLPK_BIN_DIR}/glpk.dll"
+    "${GLPK_BIN_DIR}/libltdl3.dll"
+    "${GLPK_BIN_DIR}/zlib1.dll"
+    DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  )
+endif()

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -1,19 +1,10 @@
-INCLUDE_DIRECTORIES(
-  ${PROJECT_SOURCE_DIR}
-  ${PROJECT_BINARY_DIR}
-)
-
-LINK_DIRECTORIES(
-  ${PROJECT_BINARY_DIR}/lemon
-)
-
-# Uncomment (and adjust) the following two lines. 'myprog' is the name
-# of the final executable ('.exe' will automatically be added to the
-# name on Windows) and 'myprog-main.cc' is the source code it is
-# compiled from. You can add more source files separated by
-# whitespaces. Moreover, you can add multiple similar blocks if you
-# want to build more than one executables.
-
-# ADD_EXECUTABLE(myprog myprog-main.cc)
-# TARGET_LINK_LIBRARIES(myprog lemon)
-
+# ---------------------------------------------------------------------------
+# contrib/CMakeLists.txt
+#
+# Uncomment and adjust the block below to build your own executables
+# against LEMON. Add as many blocks as needed.
+#
+# Example:
+#   add_executable(myprog myprog-main.cc)
+#   target_link_libraries(myprog PRIVATE LEMON::lemon)
+# ---------------------------------------------------------------------------

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,19 +1,20 @@
-INCLUDE_DIRECTORIES(
-  ${PROJECT_SOURCE_DIR}
-  ${PROJECT_BINARY_DIR}
-)
+# ---------------------------------------------------------------------------
+# demo/CMakeLists.txt
+# ---------------------------------------------------------------------------
 
-LINK_DIRECTORIES(
-  ${PROJECT_BINARY_DIR}/lemon
-)
+option(LEMON_BUILD_DEMOS "Build LEMON demo executables." OFF)
 
-SET(DEMOS
+if(NOT LEMON_BUILD_DEMOS)
+  return()
+endif()
+
+set(LEMON_DEMOS
   arg_parser_demo
   graph_to_eps_demo
   lgf_demo
 )
 
-FOREACH(DEMO_NAME ${DEMOS})
-  ADD_EXECUTABLE(${DEMO_NAME} ${DEMO_NAME}.cc)
-  TARGET_LINK_LIBRARIES(${DEMO_NAME} lemon)
-ENDFOREACH()
+foreach(demo IN LISTS LEMON_DEMOS)
+  add_executable(${demo} ${demo}.cc)
+  target_link_libraries(${demo} PRIVATE LEMON::lemon)
+endforeach()

--- a/lemon/CMakeLists.txt
+++ b/lemon/CMakeLists.txt
@@ -1,20 +1,25 @@
-INCLUDE_DIRECTORIES(
-  ${PROJECT_SOURCE_DIR}
-  ${PROJECT_BINARY_DIR}
+# ---------------------------------------------------------------------------
+# lemon/CMakeLists.txt
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Configure generated headers
+# ---------------------------------------------------------------------------
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/config.h.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/config.h"
 )
 
-CONFIGURE_FILE(
-  ${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
-  ${CMAKE_CURRENT_BINARY_DIR}/config.h
-)
-
-CONFIGURE_FILE(
-  ${CMAKE_CURRENT_SOURCE_DIR}/lemon.pc.in
-  ${CMAKE_CURRENT_BINARY_DIR}/lemon.pc
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/lemon.pc.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/lemon.pc"
   @ONLY
 )
 
-SET(LEMON_SOURCES
+# ---------------------------------------------------------------------------
+# Sources
+# ---------------------------------------------------------------------------
+set(LEMON_SOURCES
   arg_parser.cc
   base.cc
   color.cc
@@ -24,68 +29,148 @@ SET(LEMON_SOURCES
   bits/windows.cc
 )
 
-IF(LEMON_HAVE_GLPK)
-  SET(LEMON_SOURCES ${LEMON_SOURCES} glpk.cc)
-  INCLUDE_DIRECTORIES(${GLPK_INCLUDE_DIRS})
-  IF(WIN32)
-    INSTALL(FILES ${GLPK_BIN_DIR}/glpk.dll DESTINATION bin)
-    INSTALL(FILES ${GLPK_BIN_DIR}/libltdl3.dll DESTINATION bin)
-    INSTALL(FILES ${GLPK_BIN_DIR}/zlib1.dll DESTINATION bin)
-  ENDIF()
-ENDIF()
+if(LEMON_HAVE_GLPK)
+  list(APPEND LEMON_SOURCES glpk.cc)
+endif()
+if(LEMON_HAVE_CPLEX)
+  list(APPEND LEMON_SOURCES cplex.cc)
+endif()
+if(LEMON_HAVE_CLP)
+  list(APPEND LEMON_SOURCES clp.cc)
+endif()
+if(LEMON_HAVE_CBC)
+  list(APPEND LEMON_SOURCES cbc.cc)
+endif()
+if(LEMON_HAVE_SOPLEX)
+  list(APPEND LEMON_SOURCES soplex.cc)
+endif()
 
-IF(LEMON_HAVE_CPLEX)
-  SET(LEMON_SOURCES ${LEMON_SOURCES} cplex.cc)
-  INCLUDE_DIRECTORIES(${ILOG_INCLUDE_DIRS})
-ENDIF()
+# ---------------------------------------------------------------------------
+# Library type  (contrôlé par BUILD_SHARED_LIBS, standard CMake)
+#   cmake -DBUILD_SHARED_LIBS=ON  ...   → shared (.so / .dll)
+#   cmake -DBUILD_SHARED_LIBS=OFF ...   → static (.a / .lib)  [défaut]
+# ---------------------------------------------------------------------------
+add_library(lemon ${LEMON_SOURCES})
 
-IF(LEMON_HAVE_CLP)
-  SET(LEMON_SOURCES ${LEMON_SOURCES} clp.cc)
-  INCLUDE_DIRECTORIES(${COIN_INCLUDE_DIRS})
-ENDIF()
+# Alias pour que les consumers internes utilisent le même nom que l'extérieur
+add_library(LEMON::lemon ALIAS lemon)
 
-IF(LEMON_HAVE_CBC)
-  SET(LEMON_SOURCES ${LEMON_SOURCES} cbc.cc)
-  INCLUDE_DIRECTORIES(${COIN_INCLUDE_DIRS})
-ENDIF()
-
-IF(LEMON_HAVE_SOPLEX)
-  SET(LEMON_SOURCES ${LEMON_SOURCES} soplex.cc)
-  INCLUDE_DIRECTORIES(${SOPLEX_INCLUDE_DIRS})
-ENDIF()
-
-ADD_LIBRARY(lemon ${LEMON_SOURCES})
-
-TARGET_LINK_LIBRARIES(lemon
-  ${GLPK_LIBRARIES} ${COIN_LIBRARIES} ${ILOG_LIBRARIES} ${SOPLEX_LIBRARIES}
-  )
-
-IF(UNIX)
-  SET_TARGET_PROPERTIES(lemon PROPERTIES OUTPUT_NAME emon VERSION ${LEMON_VERSION} SOVERSION ${LEMON_VERSION})
-ENDIF()
-
-INSTALL(
-  TARGETS lemon
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  COMPONENT library
+# ---------------------------------------------------------------------------
+# Propriétés de la cible
+# ---------------------------------------------------------------------------
+# Note: CXX_VISIBILITY_PRESET hidden n'est pas utilisé ici car les headers
+# publics de lemon n'ont pas de macros d'export (LEMON_API) sur leurs
+# déclarations. Activer hidden visibility sans annoter les headers cache tous
+# les symboles dans la .so → undefined reference à la link.
+# Pour une shared lib, on laisse la visibilité par défaut (public).
+set_target_properties(lemon PROPERTIES
+  OUTPUT_NAME   "emon"
+  VERSION       "${PROJECT_VERSION}"
+  SOVERSION     "${PROJECT_VERSION_MAJOR}"        # ABI : majeur seulement
+  # Position-independent code : obligatoire pour les .so, inoffensif pour .a
+  POSITION_INDEPENDENT_CODE ON
 )
 
-INSTALL(
-  DIRECTORY . bits concepts
-  DESTINATION include/lemon
-  COMPONENT headers
+# ---------------------------------------------------------------------------
+# Warning flags — copiés directement depuis lemon_warnings (PRIVATE/BUILD only)
+# On n'utilise pas target_link_libraries(lemon PRIVATE lemon_warnings) car
+# CMake inclut quand même les INTERFACE targets PRIVATE dans l'export set,
+# ce qui provoque : "requires target lemon_warnings that is not in any export set"
+# ---------------------------------------------------------------------------
+target_compile_options(lemon
+  PRIVATE
+    $<BUILD_INTERFACE:$<TARGET_PROPERTY:lemon_warnings,INTERFACE_COMPILE_OPTIONS>>
+)
+
+# ---------------------------------------------------------------------------
+# Includes
+# ---------------------------------------------------------------------------
+target_include_directories(lemon
+  PUBLIC
+    # consumers (build tree)
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>   # config.h + lemon_export.h
+    # consumers (install tree)
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  PRIVATE
+    # solvers — uniquement nécessaires lors de la compilation de lemon lui-même
+    $<$<BOOL:${LEMON_HAVE_GLPK}>:${GLPK_INCLUDE_DIRS}>
+    $<$<BOOL:${LEMON_HAVE_CPLEX}>:${ILOG_INCLUDE_DIRS}>
+    $<$<BOOL:${LEMON_HAVE_CLP}>:${COIN_INCLUDE_DIRS}>
+    $<$<BOOL:${LEMON_HAVE_CBC}>:${COIN_INCLUDE_DIRS}>
+    $<$<BOOL:${LEMON_HAVE_SOPLEX}>:${SOPLEX_INCLUDE_DIRS}>
+)
+
+# ---------------------------------------------------------------------------
+# Link
+# ---------------------------------------------------------------------------
+target_link_libraries(lemon
+  PRIVATE
+    $<$<BOOL:${GLPK_LIBRARIES}>:${GLPK_LIBRARIES}>
+    $<$<BOOL:${COIN_LIBRARIES}>:${COIN_LIBRARIES}>
+    $<$<BOOL:${ILOG_LIBRARIES}>:${ILOG_LIBRARIES}>
+    $<$<BOOL:${SOPLEX_LIBRARIES}>:${SOPLEX_LIBRARIES}>
+    $<$<BOOL:${LEMON_USE_PTHREAD}>:Threads::Threads>
+)
+
+# ---------------------------------------------------------------------------
+# Install — cible
+# ---------------------------------------------------------------------------
+
+include(GNUInstallDirs)
+
+install(
+  TARGETS lemon
+  EXPORT  LEMONTargets
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"   COMPONENT library
+  LIBRARY DESTINATION "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"   COMPONENT library
+  RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}"   COMPONENT library  # .dll Windows
+)
+
+# ---------------------------------------------------------------------------
+# Install — headers publics
+# ---------------------------------------------------------------------------
+install(
+  DIRECTORY   "${CMAKE_CURRENT_SOURCE_DIR}/"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/lemon"
+  COMPONENT   headers
   FILES_MATCHING PATTERN "*.h"
 )
 
-INSTALL(
-  FILES ${CMAKE_CURRENT_BINARY_DIR}/config.h
-  DESTINATION include/lemon
-  COMPONENT headers
+install(
+  FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/config.h"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/lemon"
+  COMPONENT   headers
 )
 
-INSTALL(
-  FILES ${CMAKE_CURRENT_BINARY_DIR}/lemon.pc
-  DESTINATION lib/pkgconfig
+# ---------------------------------------------------------------------------
+# Install — pkg-config
+# ---------------------------------------------------------------------------
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/lemon.pc"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
 )
 
+# ---------------------------------------------------------------------------
+# Install — export set (consommé par LEMONConfig.cmake)
+# ---------------------------------------------------------------------------
+install(
+  EXPORT      LEMONTargets
+  NAMESPACE   LEMON::
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/lemon/cmake"
+  COMPONENT   headers
+)
+
+# ---------------------------------------------------------------------------
+# DLL Windows : copie des DLL tierces
+# ---------------------------------------------------------------------------
+if(WIN32 AND LEMON_HAVE_GLPK)
+  install(FILES
+    "${GLPK_BIN_DIR}/glpk.dll"
+    "${GLPK_BIN_DIR}/libltdl3.dll"
+    "${GLPK_BIN_DIR}/zlib1.dll"
+    DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  )
+endif()

--- a/lemon/arg_parser.cc
+++ b/lemon/arg_parser.cc
@@ -221,7 +221,7 @@ namespace lemon {
                                 const std::string &opt)
   {
     Opts::iterator o = _opts.find(opt);
-    Opts::iterator s = _opts.find(syn);
+    [[maybe_unused]] Opts::iterator s = _opts.find(syn);
     LEMON_ASSERT(o!=_opts.end(), "Unknown option: '"+opt+"'");
     LEMON_ASSERT(s==_opts.end(), "Option already used: '"+syn+"'");
     ParData p;

--- a/lemon/maps.h
+++ b/lemon/maps.h
@@ -1969,8 +1969,13 @@ namespace lemon {
     /// be accessed in the <tt>[beginValue, endValue)</tt> range.
     /// They are considered with multiplicity, so each value is
     /// traversed for each item it is assigned to.
-    class ValueIt
-      : public std::iterator<std::forward_iterator_tag, Value> {
+    class ValueIt {
+    public:
+      using iterator_category = std::forward_iterator_tag;
+      using value_type        = Value;
+      using difference_type   = std::ptrdiff_t;
+      using pointer           = Value*;
+      using reference         = Value&;
       friend class CrossRefMap;
     private:
       ValueIt(typename Container::const_iterator _it)
@@ -3131,8 +3136,13 @@ namespace lemon {
     /// This iterator is an STL compatible forward
     /// iterator on the values of the map. The values can
     /// be accessed in the <tt>[beginValue, endValue)</tt> range.
-    class ValueIt
-      : public std::iterator<std::forward_iterator_tag, Value> {
+    class ValueIt {
+    public:
+      using iterator_category = std::forward_iterator_tag;
+      using value_type        = Value;
+      using difference_type   = std::ptrdiff_t;
+      using pointer           = Value*;
+      using reference         = Value&;
       friend class IterableValueMap;
     private:
       ValueIt(typename std::map<Value, Key>::const_iterator _it)

--- a/lemon/random.h
+++ b/lemon/random.h
@@ -249,8 +249,8 @@ namespace lemon {
 
         current = state + length;
 
-        register Word *curr = state + length - 1;
-        register long num;
+        Word *curr = state + length - 1;
+        long num;
 
         num = length - shift;
         while (num--) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,17 +1,51 @@
-INCLUDE_DIRECTORIES(
-  ${PROJECT_SOURCE_DIR}
-  ${PROJECT_BINARY_DIR}
-)
+# ---------------------------------------------------------------------------
+# test/CMakeLists.txt
+# ---------------------------------------------------------------------------
 
-LINK_DIRECTORIES(
-  ${PROJECT_BINARY_DIR}/lemon
-)
+option(LEMON_BUILD_TESTS "Build LEMON test executables." OFF)
 
-SET(TEST_WITH_VALGRIND "NO" CACHE STRING
-  "Run the test with valgrind (YES/NO).")
-SET(VALGRIND_FLAGS "" CACHE STRING "Valgrind flags used by the tests.")
+if(NOT LEMON_BUILD_TESTS)
+  return()
+endif()
 
-SET(TESTS
+# ---------------------------------------------------------------------------
+# Valgrind
+# ---------------------------------------------------------------------------
+option(LEMON_TEST_WITH_VALGRIND "Run tests under valgrind." OFF)
+set(LEMON_VALGRIND_FLAGS "" CACHE STRING "Extra valgrind flags for tests.")
+
+# ---------------------------------------------------------------------------
+# Helper : enregistre un test, avec ou sans valgrind
+# ---------------------------------------------------------------------------
+function(lemon_add_test target)
+  if(LEMON_TEST_WITH_VALGRIND)
+    add_test(
+      NAME    ${target}
+      COMMAND valgrind --error-exitcode=1 ${LEMON_VALGRIND_FLAGS}
+              $<TARGET_FILE:${target}>
+    )
+  else()
+    add_test(NAME ${target} COMMAND ${target})
+  endif()
+  add_dependencies(check ${target})
+endfunction()
+
+# ---------------------------------------------------------------------------
+# Helper : crée un exécutable de test (EXCLUDE_FROM_ALL hors Maintainer)
+# ---------------------------------------------------------------------------
+function(lemon_add_test_executable target)
+  if(CMAKE_BUILD_TYPE STREQUAL "Maintainer")
+    add_executable(${target} ${target}.cc)
+  else()
+    add_executable(${target} EXCLUDE_FROM_ALL ${target}.cc)
+  endif()
+  target_link_libraries(${target} PRIVATE LEMON::lemon)
+endfunction()
+
+# ---------------------------------------------------------------------------
+# Tests standards
+# ---------------------------------------------------------------------------
+set(LEMON_TESTS
   adaptors_test
   arc_look_up_test
   bellman_ford_test
@@ -56,106 +90,78 @@ SET(TESTS
   unionfind_test
 )
 
-IF(LEMON_HAVE_LP)
-  IF(${CMAKE_BUILD_TYPE} STREQUAL "Maintainer")
-    ADD_EXECUTABLE(lp_test lp_test.cc)
-  ELSE()
-    ADD_EXECUTABLE(lp_test EXCLUDE_FROM_ALL lp_test.cc)
-  ENDIF()
+foreach(test IN LISTS LEMON_TESTS)
+  lemon_add_test_executable(${test})
+  lemon_add_test(${test})
+endforeach()
 
-  SET(LP_TEST_LIBS lemon)
+# ---------------------------------------------------------------------------
+# LP test (nécessite au moins un solver LP)
+# ---------------------------------------------------------------------------
+if(LEMON_HAVE_LP)
+  lemon_add_test_executable(lp_test)
 
-  IF(LEMON_HAVE_GLPK)
-    SET(LP_TEST_LIBS ${LP_TEST_LIBS} ${GLPK_LIBRARIES})
-  ENDIF()
-  IF(LEMON_HAVE_CPLEX)
-    SET(LP_TEST_LIBS ${LP_TEST_LIBS} ${ILOG_LIBRARIES})
-  ENDIF()
-  IF(LEMON_HAVE_CLP)
-    SET(LP_TEST_LIBS ${LP_TEST_LIBS} ${COIN_CLP_LIBRARIES})
-  ENDIF()
-  IF(LEMON_HAVE_SOPLEX)
-    SET(LP_TEST_LIBS ${LP_TEST_LIBS} ${SOPLEX_LIBRARIES})
-  ENDIF()
+  # Les solvers sont linkés en PRIVATE : détails d'implémentation du test
+  target_link_libraries(lp_test PRIVATE
+    $<$<BOOL:${LEMON_HAVE_GLPK}>:${GLPK_LIBRARIES}>
+    $<$<BOOL:${LEMON_HAVE_CPLEX}>:${ILOG_LIBRARIES}>
+    $<$<BOOL:${LEMON_HAVE_CLP}>:${COIN_CLP_LIBRARIES}>
+    $<$<BOOL:${LEMON_HAVE_SOPLEX}>:${SOPLEX_LIBRARIES}>
+  )
 
-  TARGET_LINK_LIBRARIES(lp_test ${LP_TEST_LIBS})
-  ADD_TEST(lp_test lp_test)
-  ADD_DEPENDENCIES(check lp_test)
+  lemon_add_test(lp_test)
 
-  IF(WIN32 AND LEMON_HAVE_GLPK)
-    GET_TARGET_PROPERTY(TARGET_LOC lp_test LOCATION)
-    GET_FILENAME_COMPONENT(TARGET_PATH ${TARGET_LOC} PATH)
-    ADD_CUSTOM_COMMAND(TARGET lp_test POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy ${GLPK_BIN_DIR}/glpk.dll ${TARGET_PATH}
-      COMMAND ${CMAKE_COMMAND} -E copy ${GLPK_BIN_DIR}/libltdl3.dll ${TARGET_PATH}
-      COMMAND ${CMAKE_COMMAND} -E copy ${GLPK_BIN_DIR}/zlib1.dll ${TARGET_PATH}
-    )
-  ENDIF()
+  # Copie des DLL solver au même endroit que l'exécutable (Windows only)
+  if(WIN32)
+    if(LEMON_HAVE_GLPK)
+      add_custom_command(TARGET lp_test POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+          "${GLPK_BIN_DIR}/glpk.dll"
+          "${GLPK_BIN_DIR}/libltdl3.dll"
+          "${GLPK_BIN_DIR}/zlib1.dll"
+          "$<TARGET_FILE_DIR:lp_test>"
+      )
+    endif()
+    if(LEMON_HAVE_CPLEX)
+      add_custom_command(TARGET lp_test POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+          "${ILOG_CPLEX_DLL}"
+          "$<TARGET_FILE_DIR:lp_test>"
+      )
+    endif()
+  endif()
+endif()
 
-  IF(WIN32 AND LEMON_HAVE_CPLEX)
-    GET_TARGET_PROPERTY(TARGET_LOC lp_test LOCATION)
-    GET_FILENAME_COMPONENT(TARGET_PATH ${TARGET_LOC} PATH)
-    ADD_CUSTOM_COMMAND(TARGET lp_test POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy ${ILOG_CPLEX_DLL} ${TARGET_PATH}
-    )
-  ENDIF()
-ENDIF()
+# ---------------------------------------------------------------------------
+# MIP test (nécessite au moins un solver MIP)
+# ---------------------------------------------------------------------------
+if(LEMON_HAVE_MIP)
+  lemon_add_test_executable(mip_test)
 
-IF(LEMON_HAVE_MIP)
-  IF(${CMAKE_BUILD_TYPE} STREQUAL "Maintainer")
-    ADD_EXECUTABLE(mip_test mip_test.cc)
-  ELSE()
-    ADD_EXECUTABLE(mip_test EXCLUDE_FROM_ALL mip_test.cc)
-  ENDIF()
+  target_link_libraries(mip_test PRIVATE
+    $<$<BOOL:${LEMON_HAVE_GLPK}>:${GLPK_LIBRARIES}>
+    $<$<BOOL:${LEMON_HAVE_CPLEX}>:${ILOG_LIBRARIES}>
+    $<$<BOOL:${LEMON_HAVE_CBC}>:${COIN_CBC_LIBRARIES}>
+  )
 
-  SET(MIP_TEST_LIBS lemon)
+  lemon_add_test(mip_test)
 
-  IF(LEMON_HAVE_GLPK)
-    SET(MIP_TEST_LIBS ${MIP_TEST_LIBS} ${GLPK_LIBRARIES})
-  ENDIF()
-  IF(LEMON_HAVE_CPLEX)
-    SET(MIP_TEST_LIBS ${MIP_TEST_LIBS} ${ILOG_LIBRARIES})
-  ENDIF()
-  IF(LEMON_HAVE_CBC)
-    SET(MIP_TEST_LIBS ${MIP_TEST_LIBS} ${COIN_CBC_LIBRARIES})
-  ENDIF()
-
-  TARGET_LINK_LIBRARIES(mip_test ${MIP_TEST_LIBS})
-  ADD_TEST(mip_test mip_test)
-  ADD_DEPENDENCIES(check mip_test)
-
-  IF(WIN32 AND LEMON_HAVE_GLPK)
-    GET_TARGET_PROPERTY(TARGET_LOC mip_test LOCATION)
-    GET_FILENAME_COMPONENT(TARGET_PATH ${TARGET_LOC} PATH)
-    ADD_CUSTOM_COMMAND(TARGET mip_test POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy ${GLPK_BIN_DIR}/glpk.dll ${TARGET_PATH}
-      COMMAND ${CMAKE_COMMAND} -E copy ${GLPK_BIN_DIR}/libltdl3.dll ${TARGET_PATH}
-      COMMAND ${CMAKE_COMMAND} -E copy ${GLPK_BIN_DIR}/zlib1.dll ${TARGET_PATH}
-    )
-  ENDIF()
-
-  IF(WIN32 AND LEMON_HAVE_CPLEX)
-    GET_TARGET_PROPERTY(TARGET_LOC mip_test LOCATION)
-    GET_FILENAME_COMPONENT(TARGET_PATH ${TARGET_LOC} PATH)
-    ADD_CUSTOM_COMMAND(TARGET mip_test POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy ${ILOG_CPLEX_DLL} ${TARGET_PATH}
-    )
-  ENDIF()
-ENDIF()
-
-FOREACH(TEST_NAME ${TESTS})
-  IF(${CMAKE_BUILD_TYPE} STREQUAL "Maintainer")
-    ADD_EXECUTABLE(${TEST_NAME} ${TEST_NAME}.cc)
-  ELSE()
-    ADD_EXECUTABLE(${TEST_NAME} EXCLUDE_FROM_ALL ${TEST_NAME}.cc)
-  ENDIF()
-  TARGET_LINK_LIBRARIES(${TEST_NAME} lemon)
-    IF(TEST_WITH_VALGRIND)
-      ADD_TEST(${TEST_NAME}
-        valgrind --error-exitcode=1 ${VALGRIND_FLAGS}
-        ${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME} )
-    ELSE()
-      ADD_TEST(${TEST_NAME} ${TEST_NAME})
-    ENDIF()
-  ADD_DEPENDENCIES(check ${TEST_NAME})
-ENDFOREACH()
+  if(WIN32)
+    if(LEMON_HAVE_GLPK)
+      add_custom_command(TARGET mip_test POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+          "${GLPK_BIN_DIR}/glpk.dll"
+          "${GLPK_BIN_DIR}/libltdl3.dll"
+          "${GLPK_BIN_DIR}/zlib1.dll"
+          "$<TARGET_FILE_DIR:mip_test>"
+      )
+    endif()
+    if(LEMON_HAVE_CPLEX)
+      add_custom_command(TARGET mip_test POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+          "${ILOG_CPLEX_DLL}"
+          "$<TARGET_FILE_DIR:mip_test>"
+      )
+    endif()
+  endif()
+endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,31 +1,34 @@
-INCLUDE_DIRECTORIES(
-  ${PROJECT_SOURCE_DIR}
-  ${PROJECT_BINARY_DIR}
+# ---------------------------------------------------------------------------
+# tools/CMakeLists.txt
+# ---------------------------------------------------------------------------
+
+option(LEMON_BUILD_TOOLS "Build LEMON tool executables." OFF)
+
+if(NOT LEMON_BUILD_TOOLS)
+  return()
+endif()
+
+set(LEMON_TOOLS
+  lgf-gen
+  dimacs-to-lgf
+  dimacs-solver
 )
 
-LINK_DIRECTORIES(
-  ${PROJECT_BINARY_DIR}/lemon
-)
+foreach(tool IN LISTS LEMON_TOOLS)
+  add_executable(${tool} ${tool}.cc)
+  target_link_libraries(${tool} PRIVATE LEMON::lemon)
+endforeach()
 
-ADD_EXECUTABLE(lgf-gen lgf-gen.cc)
-TARGET_LINK_LIBRARIES(lgf-gen lemon)
-
-ADD_EXECUTABLE(dimacs-to-lgf dimacs-to-lgf.cc)
-TARGET_LINK_LIBRARIES(dimacs-to-lgf lemon)
-
-ADD_EXECUTABLE(dimacs-solver dimacs-solver.cc)
-TARGET_LINK_LIBRARIES(dimacs-solver lemon)
-
-INSTALL(
-  TARGETS lgf-gen dimacs-to-lgf dimacs-solver
-  RUNTIME DESTINATION bin
+install(
+  TARGETS   ${LEMON_TOOLS}
+  RUNTIME   DESTINATION "${CMAKE_INSTALL_BINDIR}"
   COMPONENT bin
 )
 
-IF(NOT WIN32)
-  INSTALL(
-    PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/lemon-0.x-to-1.x.sh
-    DESTINATION bin
+if(UNIX)
+  install(
+    PROGRAMS  "${CMAKE_CURRENT_SOURCE_DIR}/lemon-0.x-to-1.x.sh"
+    DESTINATION "${CMAKE_INSTALL_BINDIR}"
     COMPONENT bin
   )
-ENDIF()
+endif()


### PR DESCRIPTION
build: replace legacy CMake with modern target-based build system

- Drop hg-based version detection in favor of LEMON_VERSION env var
- Add BUILD_SHARED_LIBS support (static default)
- Introduce imported target LEMON::lemon with CMakePackageConfigHelpers
- Switch demo/tools/test to optional builds (OFF by default)
- Replace deprecated LOCATION property with TARGET_FILE_DIR genex
- Remove global include_directories/link_directories throughout